### PR TITLE
Upgraded GuzzleHTTP to 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,31 @@
 {
-    "name": "thecsea/osticket-php-client",
-    "description": "Rest php client for osticket",
-    "minimum-stability": "stable",
-    "keywords": ["rest","osticket", "client"],
-    "license": "GPL-3.0",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Claudio Cardinale",
-            "email": "cardi@thecsea.it",
-            "homepage": "http://thecsea.it"
-        }
-    ],
-    "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.2"
-
-    },
-    "require-dev":{
-        "phpunit/phpunit": "~4.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "it\\thecsea\\osticket_php_client\\": "src/"
-        }
+  "name": "thecsea/osticket-php-client",
+  "description": "Rest php client for osticket",
+  "minimum-stability": "stable",
+  "keywords": [
+    "rest",
+    "osticket",
+    "client"
+  ],
+  "license": "GPL-3.0",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Claudio Cardinale",
+      "email": "cardi@thecsea.it",
+      "homepage": "http://thecsea.it"
     }
+  ],
+  "require": {
+    "php": ">=5.5.0",
+    "guzzlehttp/guzzle": "^7.2"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~4.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "it\\thecsea\\osticket_php_client\\": "src/"
+    }
+  }
 }

--- a/src/OsticketPhpClient.php
+++ b/src/OsticketPhpClient.php
@@ -114,7 +114,7 @@ class OsticketPhpClient
         if ($res->getStatusCode() != 201)
             throw new OsticketPhpClientException("Server error: " . $res->getStatusCode());
         try {
-            return \GuzzleHttp\json_decode($res->getBody(), true);
+            return \GuzzleHttp\Utils::jsonDecode($res->getBody(), true);
         }catch(\Exception $e){
             throw new OsticketPhpClientException("Error during parsing response",0,$e);
         }


### PR DESCRIPTION
I upgraded GuzzleHTTP to 7.2 for compatibility with other packages requiring GuzzleHTTP 7.2. 
I changed used deprecated methods to their new equivalent.